### PR TITLE
 Publish revision handlers to PublicResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "^5.9.0",
     "eslint-config-web3studio": "^1.1.0",
     "husky": "^1.2.0",
+    "jest-matchers": "^20.0.3",
     "lerna": "^3.5.0",
     "prettier": "^1.15.2",
     "pretty-quick": "^1.8.0",

--- a/packages/soy-contracts/.solcover.js
+++ b/packages/soy-contracts/.solcover.js
@@ -1,3 +1,4 @@
 module.exports = {
-  skipFiles: ['TestSetup.sol']
+  skipFiles: ['TestSetup.sol'],
+  copyPackages: ['@ensdomains/resolver']
 };

--- a/packages/soy-contracts/contracts/SoyPublicResolver.sol
+++ b/packages/soy-contracts/contracts/SoyPublicResolver.sol
@@ -8,9 +8,114 @@ import "@ensdomains/resolver/contracts/PublicResolver.sol";
  * address.
  */
 contract SoyPublicResolver is PublicResolver {
+
+  event DefaultAliasChanged(bytes32 indexed defaultAlias, string name);
+  event RevisionPublished(bytes32 indexed node, bytes hash);
+
+  struct SoyRecord {
+    string defaultAlias;
+    mapping(string=>uint256) aliases;
+    bytes[] revs;
+  }
+
+  mapping (bytes32 => SoyRecord) soyRecords;
+
   /**
    * Constructor.
+   *
    * @param ensAddr The ENS registrar contract.
    */
   constructor(ENS ensAddr) PublicResolver(ensAddr) public {}
+
+  /**
+   * Sets the default alias associated with an ENS node.
+   * May only be called by the owner of that node in the ENS registry.
+   *
+   * @param node The node to update.
+   * @param defaultAlias The default alias to set.
+   */
+  function setDefaultAlias(bytes32 node, string defaultAlias) public onlyOwner(node) {
+    soyRecords[node].defaultAlias = defaultAlias;
+    emit DefaultAliasChanged(node, defaultAlias);
+  }
+
+  /**
+   * Returns the default alias associated with an ENS node.
+   *
+   * @param node The ENS node to query.
+   * @return The associated default alias.
+   */
+  function defaultAlias(bytes32 node) public view returns (string) {
+    string storage recordDefaultAlias = soyRecords[node].defaultAlias;
+
+    return bytes(recordDefaultAlias).length > 0 ? recordDefaultAlias : "latest";
+  }
+
+  /**
+   * Sets the revision alias with an ENS node.
+   * May only be called by the owner of that node in the ENS registry.
+   *
+   * @param node The node to update.
+   * @param revNumber The revision number to set an alias to
+   * @param alias The alias to set.
+   */
+  function setRevisionAlias(bytes32 node, uint256 revNumber, string alias) public onlyOwner(node) {
+    soyRecords[node].aliases[alias] = revNumber;
+  }
+
+  /**
+   * Publishes a new hash revision associated with an ENS node.
+   * May only be called by the owner of that node in the ENS registry.
+   *
+   * @param node The node to update.
+   * @param hash The contenthash to set
+   * @return the revision number published
+   */
+  function publishRevision(bytes32 node, bytes hash) public onlyOwner(node) returns(uint256) {
+    return publishRevision(node, hash, defaultAlias(node));
+  }
+
+  /**
+   * Publishes a new hash revision associated with an ENS node.
+   * May only be called by the owner of that node in the ENS registry.
+   *
+   * @param node The node to update.
+   * @param hash The contenthash to set
+   * @param alias The alias to set to new revision
+   * @return the revision number published
+   */
+  function publishRevision(bytes32 node, bytes hash, string alias) public onlyOwner(node) returns(uint256) {
+    SoyRecord storage record = soyRecords[node];
+
+    uint256 revNumber = record.revs.push(hash) - 1;
+    setRevisionAlias(node, revNumber, alias);
+
+    emit RevisionPublished(node, hash);
+
+    return revNumber;
+  }
+
+  /**
+   * Override base contract implementation
+   *
+   * @param node The node to update.
+   * @param hash The contenthash to set
+   */
+  function setContenthash(bytes32 node, bytes hash) public onlyOwner(node) {
+    revert("Unable to set content hash directly. Use `publishRevision` instead");
+  }
+
+  /**
+   * Returns the contenthash associated with the revision set by the defaultAlias
+   *
+   * @param node The ENS node to query.
+   * @return The associated contenthash.
+   */
+  function contenthash(bytes32 node) public view returns (bytes) {
+    bytes memory empty;
+    SoyRecord storage record = soyRecords[node];
+    uint256 rev = record.aliases[defaultAlias(node)];
+
+    return record.revs.length > 0 ? record.revs[rev] : empty;
+  }
 }

--- a/packages/soy-contracts/test/SoyPublicResolver.test.js
+++ b/packages/soy-contracts/test/SoyPublicResolver.test.js
@@ -1,3 +1,4 @@
+const expect = require('jest-matchers');
 const ENS = artifacts.require('@ensdomains/ens/contracts/ENSRegistry.sol');
 const PublicResolver = artifacts.require('SoyPublicResolver.sol');
 
@@ -11,7 +12,7 @@ const namehash = require('eth-ens-namehash');
  * @param {Array} expectedPoints - Array of expected points
  */
 function assertPubKey(actual, expectedPoints) {
-  assert.deepEqual(actual, {
+  expect(actual).toEqual({
     '0': expectedPoints[0],
     '1': expectedPoints[1],
     x: expectedPoints[0],
@@ -20,6 +21,9 @@ function assertPubKey(actual, expectedPoints) {
 }
 
 contract('SoyPublicResolver', function(accounts) {
+  const fromAccount0 = { from: accounts[0] };
+  const fromAccount1 = { from: accounts[1] };
+
   let node;
   let ens, resolver;
 
@@ -40,6 +44,8 @@ contract('SoyPublicResolver', function(accounts) {
 
   describe('fallback function', async () => {
     it('forbids calls to the fallback function with 0 value', async () => {
+      expect.hasAssertions();
+
       try {
         await web3.eth.sendTransaction({
           from: accounts[0],
@@ -49,11 +55,11 @@ contract('SoyPublicResolver', function(accounts) {
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('transfer did not fail');
     });
 
     it('forbids calls to the fallback function with 1 value', async () => {
+      expect.hasAssertions();
+
       try {
         await web3.eth.sendTransaction({
           from: accounts[0],
@@ -64,85 +70,113 @@ contract('SoyPublicResolver', function(accounts) {
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('transfer did not fail');
     });
   });
 
   describe('supportsInterface function', async () => {
     it('supports known interfaces', async () => {
-      assert.equal(await resolver.supportsInterface('0x3b3b57de'), true);
-      assert.equal(await resolver.supportsInterface('0x691f3431'), true);
-      assert.equal(await resolver.supportsInterface('0x2203ab56'), true);
-      assert.equal(await resolver.supportsInterface('0xc8690233'), true);
-      assert.equal(await resolver.supportsInterface('0x59d1d43c'), true);
-      assert.equal(await resolver.supportsInterface('0xbc1c58d1'), true);
+      expect(await resolver.supportsInterface('0x3b3b57de')).toBe(
+        await resolver.supportsInterface('0x3b3b57de'),
+        true
+      );
+      expect(await resolver.supportsInterface('0x691f3431')).toBe(
+        await resolver.supportsInterface('0x691f3431'),
+        true
+      );
+      expect(await resolver.supportsInterface('0x2203ab56')).toBe(
+        await resolver.supportsInterface('0x2203ab56'),
+        true
+      );
+      expect(await resolver.supportsInterface('0xc8690233')).toBe(
+        await resolver.supportsInterface('0xc8690233'),
+        true
+      );
+      expect(await resolver.supportsInterface('0x59d1d43c')).toBe(
+        await resolver.supportsInterface('0x59d1d43c'),
+        true
+      );
+      expect(await resolver.supportsInterface('0xbc1c58d1')).toBe(
+        await resolver.supportsInterface('0xbc1c58d1'),
+        true
+      );
     });
 
     it('does not support a random interface', async () => {
-      assert.equal(await resolver.supportsInterface('0x3b3b57df'), false);
+      expect(await resolver.supportsInterface('0x3b3b57df')).toBe(
+        await resolver.supportsInterface('0x3b3b57df'),
+        false
+      );
     });
   });
 
   describe('addr', async () => {
     it('permits setting address by owner', async () => {
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
-      assert.equal(await resolver.addr(node), accounts[1]);
+      await resolver.setAddr(node, accounts[1], fromAccount0);
+      expect(await resolver.addr(node)).toBe(
+        await resolver.addr(node),
+        accounts[1]
+      );
     });
 
     it('can overwrite previously set address', async () => {
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
-      assert.equal(await resolver.addr(node), accounts[1]);
+      await resolver.setAddr(node, accounts[1], fromAccount0);
+      expect(await resolver.addr(node)).toBe(
+        await resolver.addr(node),
+        accounts[1]
+      );
 
-      await resolver.setAddr(node, accounts[0], { from: accounts[0] });
-      assert.equal(await resolver.addr(node), accounts[0]);
+      await resolver.setAddr(node, accounts[0], fromAccount0);
+      expect(await resolver.addr(node)).toEqual(accounts[0]);
     });
 
     it('can overwrite to same address', async () => {
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
-      assert.equal(await resolver.addr(node), accounts[1]);
+      await resolver.setAddr(node, accounts[1], fromAccount0);
+      expect(await resolver.addr(node)).toBe(
+        await resolver.addr(node),
+        accounts[1]
+      );
 
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
-      assert.equal(await resolver.addr(node), accounts[1]);
+      await resolver.setAddr(node, accounts[1], fromAccount0);
+      expect(await resolver.addr(node)).toBe(
+        await resolver.addr(node),
+        accounts[1]
+      );
     });
 
     it('forbids setting new address by non-owners', async () => {
-      try {
-        await resolver.setAddr(node, accounts[1], { from: accounts[1] });
-      } catch (error) {
-        return utils.ensureException(error);
-      }
+      expect.hasAssertions();
 
-      assert.fail('setting did not fail');
+      try {
+        await resolver.setAddr(node, accounts[1], fromAccount1);
+      } catch (error) {
+        utils.ensureException(error);
+      }
     });
 
     it('forbids writing same address by non-owners', async () => {
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
+      expect.hasAssertions();
+      await resolver.setAddr(node, accounts[1], fromAccount0);
 
       try {
-        await resolver.setAddr(node, accounts[1], { from: accounts[1] });
+        await resolver.setAddr(node, accounts[1], fromAccount1);
       } catch (error) {
-        return utils.ensureException(error);
+        utils.ensureException(error);
       }
-
-      assert.fail('writing did not fail');
     });
 
     it('forbids overwriting existing address by non-owners', async () => {
-      await resolver.setAddr(node, accounts[1], { from: accounts[0] });
+      expect.hasAssertions();
+      await resolver.setAddr(node, accounts[1], fromAccount0);
 
       try {
-        await resolver.setAddr(node, accounts[0], { from: accounts[1] });
+        await resolver.setAddr(node, accounts[0], fromAccount1);
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('overwriting did not fail');
     });
 
     it('returns zero when fetching nonexistent addresses', async () => {
-      assert.equal(
-        await resolver.addr(node),
+      expect(await resolver.addr(node)).toBe(
         '0x0000000000000000000000000000000000000000'
       );
     });
@@ -150,28 +184,28 @@ contract('SoyPublicResolver', function(accounts) {
 
   describe('name', async () => {
     it('permits setting name by owner', async () => {
-      await resolver.setName(node, 'name1', { from: accounts[0] });
-      assert.equal(await resolver.name(node), 'name1');
+      await resolver.setName(node, 'name1', fromAccount0);
+      expect(await resolver.name(node)).toEqual('name1');
     });
 
     it('can overwrite previously set names', async () => {
-      await resolver.setName(node, 'name1', { from: accounts[0] });
-      assert.equal(await resolver.name(node), 'name1');
+      await resolver.setName(node, 'name1', fromAccount0);
+      expect(await resolver.name(node)).toEqual('name1');
 
-      await resolver.setName(node, 'name2', { from: accounts[0] });
-      assert.equal(await resolver.name(node), 'name2');
+      await resolver.setName(node, 'name2', fromAccount0);
+      expect(await resolver.name(node)).toEqual('name2');
     });
 
     it('forbids setting name by non-owners', async () => {
       try {
-        await resolver.setName(node, 'name2', { from: accounts[1] });
+        await resolver.setName(node, 'name2', fromAccount1);
       } catch (error) {
         return utils.ensureException(error);
       }
     });
 
     it('returns empty when fetching nonexistent name', async () => {
-      assert.equal(await resolver.name(node), '');
+      expect(await resolver.name(node)).toEqual('');
     });
   });
 
@@ -212,18 +246,20 @@ contract('SoyPublicResolver', function(accounts) {
     });
 
     it('forbids setting value by non-owners', async () => {
+      expect.hasAssertions();
+
       try {
         await resolver.setPubkey(node, points[1], points[2], {
           from: accounts[1]
         });
       } catch (error) {
-        return utils.ensureException(error);
+        utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
 
     it('forbids writing same value by non-owners', async () => {
+      expect.hasAssertions();
+
       await resolver.setPubkey(node, points[1], points[2], {
         from: accounts[0]
       });
@@ -233,13 +269,13 @@ contract('SoyPublicResolver', function(accounts) {
           from: accounts[1]
         });
       } catch (error) {
-        return utils.ensureException(error);
+        utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
 
     it('forbids overwriting existing value by non-owners', async () => {
+      expect.hasAssertions();
+
       await resolver.setPubkey(node, points[1], points[2], {
         from: accounts[0]
       });
@@ -251,8 +287,6 @@ contract('SoyPublicResolver', function(accounts) {
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
   });
 
@@ -263,56 +297,56 @@ contract('SoyPublicResolver', function(accounts) {
 
     it('returns a contentType of 0 when nothing is available', async () => {
       const result = await resolver.ABI(node, 0xffffffff);
-      assert.deepEqual([result[0].toNumber(), result[1]], [0, null]);
+      expect([result[0].toNumber(), result[1]]).toEqual([0, null]);
     });
 
     it('returns an ABI after it has been set', async () => {
-      await resolver.setABI(node, 0x1, data, { from: accounts[0] });
+      await resolver.setABI(node, 0x1, data, fromAccount0);
       const result = await resolver.ABI(node, 0xffffffff);
-      assert.deepEqual([result[0].toNumber(), result[1]], [1, '0x666f6f']);
+      expect([result[0].toNumber(), result[1]]).toEqual([1, '0x666f6f']);
     });
 
     it('returns the first valid ABI', async () => {
-      await resolver.setABI(node, 0x2, data, { from: accounts[0] });
-      await resolver.setABI(node, 0x4, data2, { from: accounts[0] });
+      await resolver.setABI(node, 0x2, data, fromAccount0);
+      await resolver.setABI(node, 0x4, data2, fromAccount0);
 
       let result = await resolver.ABI(node, 0x7);
-      assert.deepEqual([result[0].toNumber(), result[1]], [2, '0x666f6f']);
+      expect([result[0].toNumber(), result[1]]).toEqual([2, '0x666f6f']);
 
       result = await resolver.ABI(node, 0x5);
-      assert.deepEqual([result[0].toNumber(), result[1]], [4, '0x626172']);
+      expect([result[0].toNumber(), result[1]]).toEqual([4, '0x626172']);
     });
 
     it('allows deleting ABIs', async () => {
-      await resolver.setABI(node, 0x1, data, { from: accounts[0] });
+      await resolver.setABI(node, 0x1, data, fromAccount0);
       let result = await resolver.ABI(node, 0xffffffff);
-      assert.deepEqual([result[0].toNumber(), result[1]], [1, '0x666f6f']);
+      expect([result[0].toNumber(), result[1]]).toEqual([1, '0x666f6f']);
 
       await resolver.setABI(node, 0x1, emptyData, {
         from: accounts[0]
       });
       result = await resolver.ABI(node, 0xffffffff);
-      assert.deepEqual([result[0].toNumber(), result[1]], [0, null]);
+      expect([result[0].toNumber(), result[1]]).toEqual([0, null]);
     });
 
     it('rejects invalid content types', async () => {
+      expect.hasAssertions();
+
       try {
-        await resolver.setABI(node, 0x3, data, { from: accounts[0] });
+        await resolver.setABI(node, 0x3, data, fromAccount0);
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
 
     it('forbids setting value by non-owners', async () => {
+      expect.hasAssertions();
+
       try {
-        await resolver.setABI(node, 0x1, data, { from: accounts[1] });
+        await resolver.setABI(node, 0x1, data, fromAccount1);
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
   });
 
@@ -321,142 +355,152 @@ contract('SoyPublicResolver', function(accounts) {
     const url2 = 'https://github.com/ethereum';
 
     it('permits setting text by owner', async () => {
-      await resolver.setText(node, 'url', url, { from: accounts[0] });
-      assert.equal(await resolver.text(node, 'url'), url);
+      await resolver.setText(node, 'url', url, fromAccount0);
+      expect(await resolver.text(node, 'url')).toBe(
+        await resolver.text(node, 'url'),
+        url
+      );
     });
 
     it('can overwrite previously set text', async () => {
-      await resolver.setText(node, 'url', url, { from: accounts[0] });
-      assert.equal(await resolver.text(node, 'url'), url);
+      await resolver.setText(node, 'url', url, fromAccount0);
+      expect(await resolver.text(node, 'url')).toBe(
+        await resolver.text(node, 'url'),
+        url
+      );
 
-      await resolver.setText(node, 'url', url2, { from: accounts[0] });
-      assert.equal(await resolver.text(node, 'url'), url2);
+      await resolver.setText(node, 'url', url2, fromAccount0);
+      expect(await resolver.text(node, 'url')).toBe(
+        await resolver.text(node, 'url'),
+        url2
+      );
     });
 
     it('can overwrite to same text', async () => {
-      await resolver.setText(node, 'url', url, { from: accounts[0] });
-      assert.equal(await resolver.text(node, 'url'), url);
+      await resolver.setText(node, 'url', url, fromAccount0);
+      expect(await resolver.text(node, 'url')).toBe(
+        await resolver.text(node, 'url'),
+        url
+      );
 
-      await resolver.setText(node, 'url', url, { from: accounts[0] });
-      assert.equal(await resolver.text(node, 'url'), url);
+      await resolver.setText(node, 'url', url, fromAccount0);
+      expect(await resolver.text(node, 'url')).toBe(
+        await resolver.text(node, 'url'),
+        url
+      );
     });
 
     it('forbids setting new text by non-owners', async () => {
+      expect.hasAssertions();
+
       try {
-        await resolver.setText(node, 'url', url, { from: accounts[1] });
+        await resolver.setText(node, 'url', url, fromAccount1);
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
 
     it('forbids writing same text by non-owners', async () => {
-      await resolver.setText(node, 'url', url, { from: accounts[0] });
+      expect.hasAssertions();
+
+      await resolver.setText(node, 'url', url, fromAccount0);
 
       try {
-        await resolver.setText(node, 'url', url, { from: accounts[1] });
+        await resolver.setText(node, 'url', url, fromAccount1);
       } catch (error) {
         return utils.ensureException(error);
       }
-
-      assert.fail('setting did not fail');
     });
   });
 
-  describe('contenthash', async () => {
-    it('permits setting contenthash by owner', async () => {
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-        { from: accounts[0] }
-      );
-      assert.equal(
-        await resolver.contenthash(node),
-        '0x0000000000000000000000000000000000000000000000000000000000000001'
-      );
-    });
-
-    it('can overwrite previously set contenthash', async () => {
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-        { from: accounts[0] }
-      );
-      assert.equal(
-        await resolver.contenthash(node),
-        '0x0000000000000000000000000000000000000000000000000000000000000001'
-      );
-
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000002',
-        { from: accounts[0] }
-      );
-      assert.equal(
-        await resolver.contenthash(node),
-        '0x0000000000000000000000000000000000000000000000000000000000000002'
-      );
-    });
-
-    it('can overwrite to same contenthash', async () => {
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-        { from: accounts[0] }
-      );
-      assert.equal(
-        await resolver.contenthash(node),
-        '0x0000000000000000000000000000000000000000000000000000000000000001'
-      );
-
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000002',
-        { from: accounts[0] }
-      );
-      assert.equal(
-        await resolver.contenthash(node),
-        '0x0000000000000000000000000000000000000000000000000000000000000002'
-      );
-    });
-
-    it('forbids setting contenthash by non-owners', async () => {
-      try {
-        await resolver.setContenthash(
-          node,
-          '0x0000000000000000000000000000000000000000000000000000000000000001',
-          { from: accounts[1] }
-        );
-      } catch (error) {
-        return utils.ensureException(error);
-      }
-
-      assert.fail('setting did not fail');
-    });
-
-    it('forbids writing same contenthash by non-owners', async () => {
-      await resolver.setContenthash(
-        node,
-        '0x0000000000000000000000000000000000000000000000000000000000000001',
-        { from: accounts[0] }
-      );
+  describe('contentHash', () => {
+    it('forbids setting contenthash ', async () => {
+      expect.hasAssertions();
 
       try {
         await resolver.setContenthash(
           node,
           '0x0000000000000000000000000000000000000000000000000000000000000001',
-          { from: accounts[1] }
+          fromAccount0
         );
       } catch (error) {
         return utils.ensureException(error);
       }
+    });
+  });
 
-      assert.fail('setting did not fail');
+  describe('revisions', async () => {
+    const contentHash1 = web3.utils.asciiToHex(
+      '/ipfs/QM00000000000000000000000000000000000000000000000000000000000001'
+    );
+    const contentHash2 = web3.utils.asciiToHex(
+      '/ipfs/QM00000000000000000000000000000000000000000000000000000000000002'
+    );
+
+    it('permits publishing revisions by owner', async () => {
+      await resolver.publishRevision(node, contentHash1, fromAccount0);
+
+      expect(await resolver.contenthash(node)).toBe(contentHash1);
+    });
+
+    it('can add a new revision', async () => {
+      await resolver.publishRevision(node, contentHash1, fromAccount0);
+      expect(await resolver.contenthash(node)).toBe(contentHash1);
+
+      await resolver.publishRevision(node, contentHash2, fromAccount0);
+      expect(await resolver.contenthash(node)).toBe(contentHash2);
+    });
+
+    it('can publish new revision with same contenthash', async () => {
+      await resolver.publishRevision(node, contentHash1, fromAccount0);
+      expect(await resolver.contenthash(node)).toBe(contentHash1);
+
+      await resolver.publishRevision(node, contentHash2, fromAccount0);
+      expect(await resolver.contenthash(node)).toBe(contentHash2);
+    });
+
+    it('forbids publishing new revision by non-owners', async () => {
+      expect.hasAssertions();
+
+      try {
+        await resolver.publishRevision(node, contentHash1, fromAccount1);
+      } catch (error) {
+        return utils.ensureException(error);
+      }
+    });
+
+    it('forbids publishing same contenthash by non-owners', async () => {
+      expect.hasAssertions();
+
+      await resolver.publishRevision(node, contentHash1, fromAccount0);
+
+      try {
+        await resolver.publishRevision(node, contentHash1, fromAccount1);
+      } catch (error) {
+        return utils.ensureException(error);
+      }
     });
 
     it('returns null when fetching nonexistent contenthash', async () => {
-      assert.equal(await resolver.contenthash(node), null);
+      expect(await resolver.contenthash(node)).toBe(null);
+    });
+
+    it('can perform a blue/green deploy', async () => {
+      await resolver.setDefaultAlias(node, 'green');
+
+      await resolver.publishRevision(node, contentHash1, fromAccount0);
+      expect(await resolver.contenthash(node)).toBe(contentHash1);
+
+      await resolver.publishRevision(node, contentHash2, 'blue', fromAccount0);
+
+      expect(await resolver.contenthash(node)).toBe(contentHash1);
+
+      // You would run integration tests here
+      // Note: currently "difficult" due to
+      //   https://github.com/ConsenSys/web3studio-soy/issues/14
+
+      await resolver.setRevisionAlias(node, 1, 'green');
+      expect(await resolver.contenthash(node)).toBe(contentHash2);
     });
   });
 });

--- a/packages/soy-contracts/yarn.lock
+++ b/packages/soy-contracts/yarn.lock
@@ -30,16 +30,16 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "10.12.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
+  version "10.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
 
 "@types/node@^8.0.0":
   version "8.10.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.38.tgz#e05c201a668492e534b48102aca0294898f449f6"
 
 "@types/node@^9.3.0", "@types/node@^9.4.1":
-  version "9.6.39"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.39.tgz#111cb4f5591cb6945aad34733b4e40bfd59b58fc"
+  version "9.6.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.40.tgz#2d69cefbc090cb0bb824542a4c575b14dde7d3aa"
 
 "@types/qs@^6.2.31":
   version "6.5.1"
@@ -187,7 +187,7 @@ arr-union@^3.1.0:
 
 array-flatten@1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  resolved "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -235,7 +235,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
+"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1081,8 +1081,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000912"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000912.tgz#08e650d4090a9c0ab06bfd2b46b7d3ad6dcaea28"
+  version "1.0.30000914"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000914.tgz#f802b4667c24d0255f54a95818dcf8e1aa41f624"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1299,8 +1299,8 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1605,8 +1605,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.3.47:
-  version "1.3.85"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz#5c46f790aa96445cabc57eb9d17346b1e46476fe"
+  version "1.3.88"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz#f36ab32634f49ef2b0fdc1e82e2d1cc17feb29e7"
 
 elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0:
   version "6.4.1"
@@ -2700,8 +2700,8 @@ hash-base@^3.0.0:
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
@@ -4416,7 +4416,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
 
 regexpu-core@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+  resolved "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
   dependencies:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,7 +596,7 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
-ansi-regex@^2.0.0:
+ansi-regex@^2.0.0, ansi-regex@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -604,7 +604,15 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.0.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
@@ -921,6 +929,16 @@ camelcase@^5.0.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
   version "2.4.1"
@@ -1349,6 +1367,10 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 dir-glob@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
@@ -1430,7 +1452,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -2048,6 +2070,12 @@ har-validator@~5.1.0:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  dependencies:
+    ansi-regex "^2.0.0"
+
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
@@ -2223,8 +2251,8 @@ init-package-json@^1.10.3:
     validate-npm-package-name "^3.0.0"
 
 inquirer@^6.1.0, inquirer@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
@@ -2237,7 +2265,7 @@ inquirer@^6.1.0, inquirer@^6.2.0:
     run-async "^2.2.0"
     rxjs "^6.1.0"
     string-width "^2.1.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.0.0"
     through "^2.3.6"
 
 invert-kv@^1.0.0:
@@ -2477,6 +2505,43 @@ isobject@^3.0.0, isobject@^3.0.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+jest-diff@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-20.0.3.tgz#81f288fd9e675f0fb23c75f1c2b19445fe586617"
+  dependencies:
+    chalk "^1.1.3"
+    diff "^3.2.0"
+    jest-matcher-utils "^20.0.3"
+    pretty-format "^20.0.3"
+
+jest-matcher-utils@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
+  dependencies:
+    chalk "^1.1.3"
+    pretty-format "^20.0.3"
+
+jest-matchers@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-20.0.3.tgz#ca69db1c32db5a6f707fa5e0401abb55700dfd60"
+  dependencies:
+    jest-diff "^20.0.3"
+    jest-matcher-utils "^20.0.3"
+    jest-message-util "^20.0.3"
+    jest-regex-util "^20.0.3"
+
+jest-message-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-20.0.3.tgz#6aec2844306fcb0e6e74d5796c1006d96fdd831c"
+  dependencies:
+    chalk "^1.1.3"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+
+jest-regex-util@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-20.0.3.tgz#85bbab5d133e44625b19faf8c6aa5122d085d762"
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -2783,7 +2848,7 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
 
-micromatch@^2.1.5:
+micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -3470,8 +3535,15 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+
+pretty-format@^20.0.3:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+  dependencies:
+    ansi-regex "^2.1.1"
+    ansi-styles "^3.0.0"
 
 pretty-quick@^1.8.0:
   version "1.8.0"
@@ -3488,8 +3560,8 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 progress@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -4150,6 +4222,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  dependencies:
+    ansi-regex "^4.0.0"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -4192,6 +4270,10 @@ supports-color@4.4.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
**Related Issue**  
Fixes #7 

**Related PRs**  
Depends #13 

**What does this PR do?**  
This pr intends to address the acceptance in #7. The smallest bare minumum requirement for something useful. I discovered a need to publish revisions as subnodes, I opened the requirement in #14

**Description of Changes**  
Public resolver is updated to pull content hashes out of a list of revisions.

Base `assert` changed to use jest's `expect` for cross-project consistency in tests.

**What gif most accurately describes how I feel towards this PR?**  
![monkey typing](https://media2.giphy.com/media/JgRMIPzWPgyIw/giphy.gif)
