### PR TITLE
Ens migrations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: ['web3studio', 'web3studio/truffle']
+  extends: ['web3studio', 'web3studio/truffle'],
+  parserOptions: {
+    ecmaVersion: 9
+  }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postinstall": "lerna bootstrap"
   },
   "devDependencies": {
+    "concurrently": "^4.1.0",
     "eslint": "^5.9.0",
     "eslint-config-web3studio": "^1.1.0",
     "husky": "^1.2.0",

--- a/packages/soy-contracts/.solcover.js
+++ b/packages/soy-contracts/.solcover.js
@@ -1,4 +1,4 @@
 module.exports = {
   skipFiles: ['TestSetup.sol'],
-  copyPackages: ['@ensdomains/resolver']
+  copyPackages: ['@ensdomains/resolver', '@ensdomains/ens']
 };

--- a/packages/soy-contracts/contracts/TestSetup.sol
+++ b/packages/soy-contracts/contracts/TestSetup.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.18;
 // USED TO HAVE COMPILED CONTRACTS THAT AREN'T FROM THIS PACKAGE OR USED
 
 import "@ensdomains/ens/contracts/ENSRegistry.sol";
+import "@ensdomains/ens/contracts/ReverseRegistrar.sol";
 
 
 contract TestSetup {

--- a/packages/soy-contracts/migrations/1_initial_migration.js
+++ b/packages/soy-contracts/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
 const Migrations = artifacts.require('./Migrations.sol');
 
-module.exports = function(deployer) {
+module.exports = deployer => {
   deployer.deploy(Migrations);
 };

--- a/packages/soy-contracts/migrations/2_ens_setup.js
+++ b/packages/soy-contracts/migrations/2_ens_setup.js
@@ -1,0 +1,56 @@
+const namehash = require('eth-ens-namehash');
+
+const ENSRegistry = artifacts.require(
+  '@ensdomains/ens/contracts/ENSRegistry.sol'
+);
+const ReverseRegistrar = artifacts.require(
+  '@ensdomains/ens/contracts/ReverseRegistrar.sol'
+);
+const PublicResolver = artifacts.require('SoyPublicResolver.sol');
+
+module.exports = async deployer => {
+  const accounts = await web3.eth.getAccounts();
+  const owner = accounts[0];
+  const deployOps = { from: owner };
+  const rootNode = web3.utils.asciiToHex(0);
+
+  // Only setup ENS resolvers on development network
+  if (deployer.network !== 'development') {
+    return;
+  }
+
+  await deployer.deploy(ENSRegistry);
+  await deployer.deploy(PublicResolver, ENSRegistry.address);
+
+  await deployer.deploy(
+    ReverseRegistrar,
+    ENSRegistry.address,
+    PublicResolver.address
+  );
+
+  const registry = await ENSRegistry.at(ENSRegistry.address);
+
+  // eth tld
+  await registry.setSubnodeOwner(
+    rootNode,
+    web3.utils.sha3('eth'),
+    owner,
+    deployOps
+  );
+
+  // reverse
+  await registry.setSubnodeOwner(
+    rootNode,
+    web3.utils.sha3('reverse'),
+    owner,
+    deployOps
+  );
+
+  // addr.reverse
+  await registry.setSubnodeOwner(
+    namehash.hash('reverse'),
+    web3.utils.sha3('addr'),
+    ReverseRegistrar.address,
+    deployOps
+  );
+};

--- a/packages/soy-contracts/package.json
+++ b/packages/soy-contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soy-contracts",
   "version": "0.0.0",
-  "main": "index.js",
+  "main": "src/index.js",
   "description": "ENS resolvers for soy",
   "keywords": [
     "truffle",
@@ -9,6 +9,9 @@
     "soy"
   ],
   "scripts": {
+    "start": "concurrently --kill-others-on-fail -n w: npm:start:*",
+    "start:ganache": "yarn ganache-cli -i 42 -b 1 -d",
+    "start:migrate": "yarn truffle migrate --reset && yarn truffle exec scripts/ens.js",
     "compile": "truffle compile",
     "test": "solidity-coverage"
   },
@@ -22,14 +25,18 @@
   "author": "Michael Barlock <barlockm@gmail.com>",
   "homepage": "https://github.com/ConsenSys/web3studio-soy#readme",
   "license": "Apache-2.0",
+  "dependencies": {
+    "eth-ens-namehash": "^2.0.8",
+    "truffle-contract": "^4.0.0-beta.2"
+  },
   "devDependencies": {
+    "@ensdomains/ens": "^0.1.1",
+    "@ensdomains/resolver": "^0.1.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.12",
+    "ganache-cli": "^6.2.3",
+    "pako": "^1.0.7",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.0-beta.2"
-  },
-  "dependencies": {
-    "@ensdomains/ens": "^0.1.1",
-    "@ensdomains/resolver": "^0.1.0"
   }
 }

--- a/packages/soy-contracts/scripts/ens.js
+++ b/packages/soy-contracts/scripts/ens.js
@@ -1,0 +1,55 @@
+// Allow logging to cli console
+/* eslint-disable no-console */
+
+const ENSRegistry = artifacts.require('ENSRegistry.sol');
+const PublicResolver = artifacts.require('SoyPublicResolver.sol');
+const namehash = require('eth-ens-namehash');
+const pako = require('pako');
+
+const contentHash = '/ipfs/QmVyYoFQ8KDLMUWhzxTn24js9g5BiC6QX3ZswfQ56T7A5T';
+const name = 'web3studio';
+const tld = 'eth';
+const address = `${name}.${tld}`;
+const node = namehash.hash(address);
+
+module.exports = async () => {
+  try {
+    const ensRegistry = await ENSRegistry.deployed();
+    const resolver = await PublicResolver.deployed();
+    const accounts = await web3.eth.getAccounts();
+    const owner = accounts[0];
+    const fromOwner = { from: owner };
+    const compressedABI = web3.utils.asciiToHex(
+      pako.deflate(JSON.stringify(PublicResolver.abi), {
+        to: 'string'
+      })
+    );
+
+    console.log(`Setting ${address} owner`);
+    await ensRegistry.setSubnodeOwner(
+      namehash.hash(tld),
+      web3.utils.sha3(name),
+      owner,
+      fromOwner
+    );
+
+    console.log(`Setting ${address} resolver`);
+    await ensRegistry.setResolver(node, PublicResolver.address, fromOwner);
+    await ensRegistry.setTTL(node, 300); // 5 min
+    await resolver.setABI(
+      node,
+      2, //zlib-compressed JSON
+      compressedABI,
+      fromOwner
+    );
+
+    console.log(`Publishing ${address} revision`);
+    await resolver.publishRevision(
+      node,
+      web3.utils.asciiToHex(contentHash),
+      fromOwner
+    );
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/packages/soy-contracts/src/ENS.js
+++ b/packages/soy-contracts/src/ENS.js
@@ -1,0 +1,22 @@
+const contract = require('truffle-contract');
+const ENS = require('../build/contracts/ENSRegistry.json');
+
+const ENS_ADDRESSES = {
+  '1': {
+    address: '0x314159265dd8dbb310642f98f50c066173c1259b'
+  },
+  '3': {
+    address: '0x112234455c3a32fd11230c42e7bccd4a84e02010'
+  },
+  '4': {
+    address: '0xe7410170f87102df0055eb195163a03b7f2bff4a'
+  }
+};
+
+module.exports = contract({
+  ...ENS,
+  networks: {
+    ...ENS.networks,
+    ...ENS_ADDRESSES
+  }
+});

--- a/packages/soy-contracts/src/SoyPublicResolver.js
+++ b/packages/soy-contracts/src/SoyPublicResolver.js
@@ -1,0 +1,4 @@
+const contract = require('truffle-contract');
+const SoyPublicResolver = require('../build/contracts/SoyPublicResolver.json');
+
+module.exports = contract(SoyPublicResolver);

--- a/packages/soy-contracts/src/index.js
+++ b/packages/soy-contracts/src/index.js
@@ -1,0 +1,7 @@
+const ENS = require('./ENS');
+const SoyPublicResolver = require('./SoyPublicResolver');
+
+module.exports = {
+  ENS,
+  SoyPublicResolver
+};

--- a/packages/soy-contracts/truffle.js
+++ b/packages/soy-contracts/truffle.js
@@ -1,10 +1,10 @@
 module.exports = {
   networks: {
-    // development: {
-    //   host: '127.0.0.1', // Localhost (default: none)
-    //   port: 8545, // Standard Ethereum port (default: none)
-    //   network_id: '*' // Any network (default: none)
-    // },
+    development: {
+      host: '127.0.0.1',
+      port: 8545,
+      network_id: '*'
+    },
     coverage: {
       host: 'localhost',
       network_id: '*',

--- a/packages/soy-contracts/yarn.lock
+++ b/packages/soy-contracts/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@ensdomains/ens@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.1.1.tgz#69f4a86162a229824bb1123bc794f05d4622e79c"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.1.2.tgz#f6e4cfe4aa6fbd94de40dd85ef0471e9bd787892"
   dependencies:
     eth-ens-namehash "^1.0.2"
     ethereumjs-testrpc "^6.0.3"
@@ -111,6 +111,15 @@ aes-js@^3.1.1:
 ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
+ajv@^5.1.1:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 ajv@^6.1.0, ajv@^6.5.5:
   version "6.6.1"
@@ -1081,8 +1090,8 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30000914"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000914.tgz#f802b4667c24d0255f54a95818dcf8e1aa41f624"
+  version "1.0.30000918"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz#6288f79da3c5c8b45e502f47ad8f3eb91f1379a9"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1191,6 +1200,10 @@ clone@2.1.2, clone@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1210,8 +1223,8 @@ collection-visit@^1.0.0:
     object-visit "^1.0.0"
 
 colors@^1.1.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
@@ -1226,6 +1239,10 @@ commander@2.11.0:
 commander@^2.8.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commander@~2.17.1:
   version "2.17.1"
@@ -1380,6 +1397,10 @@ crypto-js@^3.1.4:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.8.tgz#715f070bf6014f2ae992a98b3929258b713f08d5"
 
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+
 d@1:
   version "1.0.0"
   resolved "http://registry.npmjs.org/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1411,6 +1432,12 @@ debug@3.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -2129,6 +2156,14 @@ ethereumjs-wallet@0.6.2:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
+ethjs-abi@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/ethjs-abi/-/ethjs-abi-0.1.8.tgz#cd288583ed628cdfadaf8adefa3ba1dbcbca6c18"
+  dependencies:
+    bn.js "4.11.6"
+    js-sha3 "0.5.5"
+    number-to-bn "1.7.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -2271,6 +2306,10 @@ fake-merkle-patricia-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz#4b8c3acfb520afadf9860b1f14cd8ce3402cddd3"
   dependencies:
     checkpoint-store "^1.1.0"
+
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -2442,7 +2481,7 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-ganache-cli@^6.1.0:
+ganache-cli@^6.1.0, ganache-cli@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.2.3.tgz#8648224e7c54aa86c52125f8fa10fba2f549b149"
   dependencies:
@@ -3092,6 +3131,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+js-sha3@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
+
 js-sha3@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.3.1.tgz#86122802142f0828502a0d1dee1d95e253bb0243"
@@ -3151,6 +3194,10 @@ json-rpc-error@^2.0.0:
 json-rpc-random-id@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz#ba49d96aded1444dbb8da3d203748acbbcdec8c8"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -3626,8 +3673,8 @@ minipass@^2.2.1, minipass@^2.3.4:
     yallist "^3.0.0"
 
 minizlib@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   dependencies:
     minipass "^2.2.1"
 
@@ -3676,6 +3723,10 @@ mout@^0.11.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 mz@^2.6.0:
   version "2.7.0"
@@ -3995,7 +4046,7 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
-pako@~1.0.5:
+pako@^1.0.7, pako@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
 
@@ -4036,7 +4087,7 @@ pascalcase@^0.1.1:
 
 path-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+  resolved "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -4539,7 +4590,7 @@ resolve-url@^0.2.1:
 
 resolve@1.1.x:
   version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  resolved "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6:
   version "1.8.1"
@@ -4549,7 +4600,7 @@ resolve@^1.1.6:
 
 resolve@~1.7.1:
   version "1.7.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  resolved "http://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
     path-parse "^1.0.5"
 
@@ -4927,8 +4978,8 @@ source-map@~0.2.0:
     amdefine ">=0.0.4"
 
 spdx-correct@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -4956,7 +5007,7 @@ split-string@^3.0.1, split-string@^3.0.2:
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.15.2"
@@ -5341,6 +5392,37 @@ trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
+truffle-blockchain-utils@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz#a4e5c064dadd69f782a137f3d276d21095da7a47"
+
+truffle-contract-schema@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz#9bf821d32e26e674ba15eb5d40f96b10b1c9d568"
+  dependencies:
+    ajv "^5.1.1"
+    crypto-js "^3.1.9-1"
+    debug "^3.1.0"
+
+truffle-contract@^4.0.0-beta.2:
+  version "4.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-4.0.0-next.0.tgz#717b5921331ec70ca4f58a3d29ae955db80163fe"
+  dependencies:
+    ethereumjs-util "^5.2.0"
+    ethjs-abi "0.1.8"
+    truffle-blockchain-utils "^0.0.5"
+    truffle-contract-schema "^2.0.1"
+    truffle-error "^0.0.3"
+    uglify-es "^3.3.9"
+    web3 "1.0.0-beta.35"
+    web3-core-promievent "1.0.0-beta.35"
+    web3-eth-abi "1.0.0-beta.35"
+    web3-utils "1.0.0-beta.35"
+
+truffle-error@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.3.tgz#4bf55242e14deee1c7194932709182deff2c97ca"
+
 truffle@^5.0.0-beta.2:
   version "5.0.0-user-level-mnemonic.0"
   resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.0-user-level-mnemonic.0.tgz#c2c0148278353371e22e7f2e50cc41db9bade16a"
@@ -5351,7 +5433,7 @@ truffle@^5.0.0-beta.2:
 
 tty-browserify@0.0.0:
   version "0.0.0"
-  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  resolved "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -5400,6 +5482,13 @@ typewiselite@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typewiselite/-/typewiselite-1.0.0.tgz#c8882fa1bb1092c06005a97f34ef5c8508e3664e"
 
+uglify-es@^3.3.9:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -5441,7 +5530,7 @@ unbzip2-stream@^1.0.9:
 
 underscore@1.8.3:
   version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  resolved "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -5567,7 +5656,7 @@ verror@1.10.0:
 
 vm-browserify@0.0.4:
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  resolved "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
 
@@ -5812,8 +5901,8 @@ web3-utils@1.0.0-beta.35:
     utf8 "2.1.1"
 
 web3-utils@^1.0.0-beta.31:
-  version "1.0.0-beta.36"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.36.tgz#dc19c9aeec009b1816cc91ef64d7fe9f8ee344c9"
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.37.tgz#ab868a90fe5e649337e38bdaf72133fcbf4d414d"
   dependencies:
     bn.js "4.11.6"
     eth-lib "0.1.27"
@@ -5879,16 +5968,7 @@ webpack@^3.0.0:
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
 
-websocket@1.0.26:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.26.tgz#a03a01299849c35268c83044aa919c6374be8194"
-  dependencies:
-    debug "^2.2.0"
-    nan "^2.3.3"
-    typedarray-to-buffer "^3.1.2"
-    yaeti "^0.0.6"
-
-"websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
+websocket@1.0.26, "websocket@git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible":
   version "1.0.26"
   resolved "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,7 +940,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1101,6 +1101,20 @@ concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concurrently@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-4.1.0.tgz#17fdf067da71210685d9ea554423ef239da30d33"
+  dependencies:
+    chalk "^2.4.1"
+    date-fns "^1.23.0"
+    lodash "^4.17.10"
+    read-pkg "^4.0.1"
+    rxjs "^6.3.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^4.5.0"
+    tree-kill "^1.1.0"
+    yargs "^12.0.1"
+
 config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -1255,6 +1269,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.23.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -1471,8 +1489,8 @@ eslint-config-web3studio@^1.1.0:
     eslint-plugin-prettier "^3.0.0"
 
 eslint-plugin-jsdoc@^3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.9.1.tgz#ca626c7899b6b883e6b4bec441d3510f756d98d1"
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.10.0.tgz#699d739e7d3aec2403c8f952c321336b3319d1d7"
   dependencies:
     comment-parser "^0.5.0"
     jsdoctypeparser "^2.0.0-alpha-8"
@@ -2931,8 +2949,8 @@ minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
     yallist "^3.0.0"
 
 minizlib@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.0.tgz#59517387478fd98d8017ed0299c6cb16cbd12da3"
   dependencies:
     minipass "^2.2.1"
 
@@ -3905,7 +3923,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.1.0:
+rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   dependencies:
@@ -4107,9 +4125,13 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+
 spdx-correct@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -4275,6 +4297,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4384,6 +4412,10 @@ tr46@^1.0.1:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
     punycode "^2.1.0"
+
+tree-kill@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Related Issue**  
Supports #9 

**Related PRs**  
Depends #15 

**What does this PR do?**  
Adds deployment scripts for the public resolvers. I made some assumptions:
* Only works right now for development network. Adding the rest is more complicated, I'm focused on getting a POC and understanding the edges, that seemed like a distraction
* No tests: Things are still rapidly changing and I want to see where things land before testing the js exports

**Description of Changes**  
Added a ens setup that will set up the root ens registries and our public resolver. It also sets up a test node `web3studio.eth` and sets it to what is currently master of the sojourn devkit docs.

**What gif most accurately describes how I feel towards this PR?**  
![fly](https://media2.giphy.com/media/VxbvpfaTTo3le/giphy.gif)
