### PR TITLE
Add first readmes for all top level projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Soy
+
+Looking to contribute something to Soy? **Here's how you can help.**
+
+Please take a moment to review this document in order to make the contribution
+process easy and effective for everyone involved.
+
+Following these guidelines helps to communicate that you respect the time of the
+developers managing and developing this open source project. In return, they
+should reciprocate that respect in addressing your issue or assessing patches
+and features.
+
+## Setup Development Environment
+
+Soy is a monorepo that uses [yarn](https://yarnpkg.com) and [lerna](https://lernajs.io/)
+to manage dependencies during development.
+
+If you haven't installed yarn already, yarn hosts great
+[install instructions](https://yarnpkg.com/en/docs/install) for every major os.
+
+Web3js also uses python, though it isn't a requirement, you can find instructions
+to install it on [Python's website](https://www.python.org/downloads/).
+
+To install dev dependencies, use yarn:
+
+```bash
+$ yarn install
+```
+
+## Testing and Linting
+
+All code is linted (eslint, and solium), formatted (prettier), and tested
+(jest, truffle). To run the full suite of tests:
+
+```bash
+$ yarn test
+```
+
+Every individual project can also run it's own tests individually with
+`yarn test` in it's own directory as well.
+
+## Pull Requests
+
+Good pull requests—patches, improvements, new features—are a fantastic help.
+They should remain focused in scope and avoid containing unrelated commits.
+All pull requests should include tests and pass CI.
+
+Please ask first before embarking on any significant pull request
+(e.g. implementing features, refactoring code, porting to a different language),
+otherwise you risk spending a lot of time working on something that the project's
+developers might not want to merge into the project.
+
+**IMPORTANT**: By submitting a patch, you agree to allow the project owners to
+license your work under the terms of the
+[Apache 2.0](https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-core/LICENSE)
+License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+packages/soy-core/README.md

--- a/packages/soy-contracts/README.md
+++ b/packages/soy-contracts/README.md
@@ -1,11 +1,97 @@
-# `ens-resolvers`
+<h1 align="center">
+  <br/>
+  <a href='https://github.com/ConsenSys/web3studio-soy'><img 
+      width='250px' 
+      alt='' 
+      src="https://user-images.githubusercontent.com/5770007/50840308-2f093000-1330-11e9-996a-2e61a8b7fd9a.png" /></a>
+  <br/>
+  Contracts
+  <br/>
+</h1>
 
-> TODO: description
+<h4 align="center">
+  ENS+IPFS ❤ DevOps - Static Websites on the Distributed Web
+</h4>
 
+<p align="center">
+  <a href="#setup">Setup</a> ∙
+  <a href="#api">API</a> ∙
+  <a href="#license">License</a>
+</p>
+
+Soy Contracts is the source code for Soy's public ENS resolver and a low level JS interface to the contracts.
+
+<br/>
+  
 ## Usage
 
-```
-const ensResolvers = require('ens-resolvers');
+### Install
 
-// TODO: DEMONSTRATE API
+```bash
+# Yarn
+$ yarn add soy-contracts
+
+# npm
+$ npm install --save soy-contracts
 ```
+
+### API
+
+`soy-contracts` exports two smart contracts wrapped by [truffle-contract][truffle-contract].
+If you're familiar with the [Truffle console][truffle-console], then the api should feel natural.
+
+The two contract's are named exports and are:
+
+- `ENS`: The main ENS registry contract, [source][ens-registry-contract].
+- `SoyPublicResolver`: Soy's public resolver implementation, [source][soy-public-resolver-contract]
+
+For more details about API for each contract, refer to
+[Truffle's documentation][truffle-contract-docs] and the source above.
+
+### Examples
+
+### Deploying and Configuring Test Contracts
+
+```js
+const { SoyPublicResolver, ENS } = require('soy-contracts');
+
+const rootNode = web3.utils.asciiToHex(0);
+const provider = web3.currentProvider;
+const accounts = await web3.eth.getAccounts();
+const txOps = { from: accounts[0] };
+
+ENS.setProvider(provider);
+ENS.defaults(txOps);
+SoyPublicResolver.setProvider(provider);
+SoyPublicResolver.defaults(txOps);
+
+const registryContract = await ENS.new(txOps);
+const resolverContract = await SoyPublicResolver.new(
+  registryContract.address,
+  txOps
+);
+
+await registryContract.setSubnodeOwner(
+  rootNode,
+  web3.utils.sha3(tld),
+  txOps.from,
+  txOps
+);
+```
+
+## Contributing
+
+Please read through our [contributing guidelines][contributing].
+Included are directions for coding standards, and notes on development.
+
+## License
+
+[Apache 2.0][license]
+
+[license]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-contracts/LICENSE
+[contributing]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-core/CONTRIBUTING.md
+[soy-public-resolver-contract]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-contracts/contracts/SoyPublicResolver.sol
+[ens-registry-contract]: https://github.com/ensdomains/ens/blob/master/contracts/ENSRegistry.sol
+[truffle-contract]: https://github.com/trufflesuite/truffle/tree/next/packages/truffle-contract
+[truffle-contract-docs]: https://truffleframework.com/docs/truffle/getting-started/interacting-with-your-contracts
+[truffle-console]: https://truffleframework.com/docs/truffle/getting-started/using-truffle-develop-and-the-console

--- a/packages/soy-core/README.md
+++ b/packages/soy-core/README.md
@@ -1,3 +1,163 @@
-# Soy Core
+<h1 align="center">
+  <br/>
+  <a href='https://github.com/ConsenSys/web3studio-soy'><img 
+      width='250px' 
+      alt='' 
+      src="https://user-images.githubusercontent.com/5770007/50840308-2f093000-1330-11e9-996a-2e61a8b7fd9a.png" /></a>
+  <br/>
+</h1>
+
+<h4 align="center">
+  ENS+IPFS ❤ DevOps - Static Websites on the Distributed Web
+</h4>
+
+<p align="center">
+  <a href="#usage">Usage</a> ∙
+  <a href="#packages">Packages</a> ∙
+  <a href="#contributing">Contributing</a> ∙
+  <a href="#license">License</a>
+</p>
+
+Soy is a collection of smart contracts and tools to enable you to build your site
+on the distributed web. By virtue of using [ENS](https://ens.domains/) and
+[IPFS](https://ipfs.io/) your content will be quickly accessible all over the world without
+having to set up or manage any infrastructure.
+
+Already have an ENS resolver? Add `.soy` to the end to see it in your browser! Check
+out [web3studio.eth.soy][web3studio.eth.soy]
+
+<br/>
 
 ## Usage
+
+### Install
+
+```bash
+# Yarn
+$ yarn add --dev soy-core
+
+# NPM
+$ npm install --save-dev soy-core
+```
+
+### Configure
+
+Create a new soy instance and give it any Web3 provider.
+
+```js
+const Soy = require('soy-core');
+const HDWalletProvider = require('truffle-hdwallet-provider');
+
+const mnemonic = process.env.WALLET_MNEMONIC;
+const infuraApiKey = process.env.INFURA_API_KEY;
+const infuraNetwork = process.env.INFURA_NETWORK;
+const provider = new HDWalletProvider(
+  mnemonic,
+  `https://${infuraNetwork}.infura.io/v3/${infuraApiKey}`
+);
+
+const soy = new Soy({ provider });
+```
+
+### Register an ENS Domain with Soy
+
+After [purchasing an ENS Domain](https://www.myetherwallet.com/#ens) you can
+register it with Soy
+
+```js
+const resolver = await soy.registerDomain('example.madewith.eth');
+```
+
+### Using the Resolver
+
+With a registered domain, you can now publish content revisions, use aliases, or
+use it like a normal ENS contract.
+
+```js
+const resolver = await soy.resolver('example.madewith.eth');
+
+await resolver.publishRevision(
+  '/ipfs/QmVyYoFQ8KDLMUWhzxTn24js9g5BiC6QX3ZswfQ56T7A5T'
+);
+```
+
+### View Your Beautiful Site
+
+Once you have ENS set up to point to an ipfs hash, simply add `.soy` to the ENS
+domain in your browser. For example, web3studio.eth becomes
+[web3studio.eth.soy][web3studio.eth.soy].
+
+## Examples
+
+### First time registering a domain and publishing a hash
+
+```js
+const Soy = require('soy-core');
+const Web3 = require('web3');
+const HDWalletProvider = require('truffle-hdwallet-provider');
+
+// Change these paremeters or pass them in as env variables
+const mnemonic = process.env.WALLET_MNEMONIC;
+const infuraApiKey = process.env.INFURA_API_KEY;
+const infuraNetwork = process.env.INFURA_NETWORK || 'rinkeby';
+const contentHash = '/ipfs/QmVyYoFQ8KDLMUWhzxTn24js9g5BiC6QX3ZswfQ56T7A5T';
+const domain = 'soyexample.test';
+
+var provider = new HDWalletProvider(
+  mnemonic,
+  `https://${infuraNetwork}.infura.io/v3/${infuraApiKey}`
+);
+
+(async () => {
+  const web3 = new Web3(provider);
+  const accounts = await web3.eth.getAccounts();
+  const owner = accounts[0];
+
+  const soy = new Soy({ provider, from: owner });
+
+  const resolver = await soy.registerDomain(domain);
+  const revision = await resolver.publishRevision(contentHash);
+
+  console.log(`Revision ${revision} published by Soy!`);
+})().catch(console.log);
+```
+
+## Packages
+
+Soy consists of a bunch of tools that make hosting distributed web sites easy. They are:
+
+### [`soy-contracts`][soy-contracts]
+
+Contracts contains the source of the solidity contracts and a low level interface
+for interactions via [`truffle-contract`][truffle-contract].
+
+For more information, see [`soy-contracts`][soy-contracts]'s main page.
+
+### [`soy-gateway`][soy-gateway]
+
+The gateway is the source code behind eth.soy. It's a shim to enable browsers to
+support distributed file systems over ENS until browsers can handle this natively.
+
+For more information, see [`soy-gateway`][soy-gateway]'s main page.
+
+### [`soy-core`][soy-core]
+
+The core project contains a friendly js interface to interacting with the deployed
+contracts of [`soy-contracts`][soy-contracts] enabling you to get your content out there with ease.
+
+## Contributing
+
+Please read through our [contributing guidelines][contributing].
+Included are directions for coding standards, and notes on development.
+
+## License
+
+[Apache 2.0][license]
+
+[soy-contracts]: https://github.com/ConsenSys/web3studio-soy/tree/master/packages/soy-contracts
+[soy-gateway]: https://github.com/ConsenSys/web3studio-soy/tree/master/packages/soy-gateway
+[soy-core]: https://github.com/ConsenSys/web3studio-soy/tree/master/packages/soy-core
+[license]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-core/LICENSE
+[contributing]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-core/CONTRIBUTING.md
+[truffle-contract]: https://github.com/trufflesuite/truffle/tree/next/packages/truffle-contract
+[web3studio.eth.soy]: https://web3studio.eth.soy

--- a/packages/soy-gateway/README.md
+++ b/packages/soy-gateway/README.md
@@ -1,3 +1,58 @@
-# Soy Gateway
+<h1 align="center">
+  <br/>
+  <a href='https://github.com/ConsenSys/web3studio-soy'><img 
+      width='250px' 
+      alt='' 
+      src="https://user-images.githubusercontent.com/5770007/50840308-2f093000-1330-11e9-996a-2e61a8b7fd9a.png" /></a>
+  <br/>
+  Gateway
+  <br/>
+</h1>
 
-Server code for for [soy.eth](https://soy.eth)
+<h4 align="center">
+  ENS+IPFS ❤ DevOps - Static Websites on the Distributed Web
+</h4>
+
+<p align="center">
+  <a href="#setup">Setup</a> ∙
+  <a href="#contributing">Contributing</a> ∙
+  <a href="#license">License</a>
+</p>
+
+Soy Gateway is the backend behind eth.soy. Have ENS pointing to a `contenthash`?
+Add `.soy` to the end to see it in your browser! Check out [web3studio.eth.soy][web3studio.eth.soy].
+
+<br/>
+
+## Setup
+
+Soy Gateway consists of two AWS [Lambda@Edge](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html)
+functions. It uses a viewer request lambda to map an incoming request to an ipfs
+location and an origin request to rewrite the request for an IPFS gateway.
+
+In order to deploy your own version or contribute changes you'll need to set up a few things:
+
+- [AWS SAM](https://aws.amazon.com/serverless/sam/): AWS Serverless Application Model (SAM) is used to configure the aws infrastructure needed for continuous deployment.
+- [aws-cli](https://aws.amazon.com/cli/): AWS CLI is used by SAM. You'll need to [configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) it with access keys and secrets.
+
+### Development
+
+Some handy built in scripts will help you run this locally.
+
+- `yarn test` or `yarn jest`: run's [jest](https://jestjs.io) for unit tests. It uses ganache to simulate an Ethereum blockchain.
+- `yarn start`: Run's the viewer request function with a test event
+- `yarn lambda:build`: Build's the lambdas that are deployed to aws
+- `yarn lambda:deploy`: Uses AWS SAM to deploy the lambdas with a cloudfront distribution
+
+## Contributing
+
+Please read through our [contributing guidelines][contributing].
+Included are directions for coding standards, and notes on development.
+
+## License
+
+[Apache 2.0][license]
+
+[license]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-gateway/LICENSE
+[contributing]: https://github.com/ConsenSys/web3studio-soy/blob/master/packages/soy-core/CONTRIBUTING.md
+[web3studio.eth.soy]: https://web3studio.eth.soy


### PR DESCRIPTION
**Related Issue**  
Supports #34 
Fixes #35 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Sets up a base readme for every project. I'm going to circle back around to use a jsdoc generated api doc for every project also, another pr though.

**Description of Changes**  
Readme for every package, followed the pattern from Sojourn. A contributing doc that adds some of the details @breakpointer pointed out in #35.

**What gif most accurately describes how I feel towards this PR?**  
![cramp](https://thumbs.gfycat.com/UnfitWhisperedAlabamamapturtle-small.gif)
