### PR TITLE
Normalize redirect locations to the request uri

### DIFF
--- a/packages/soy-gateway/scripts/transformWebpack.js
+++ b/packages/soy-gateway/scripts/transformWebpack.js
@@ -20,7 +20,7 @@ const resolveModule = modulePath =>
 const testPattern = /\.test\.js$/;
 
 module.exports = config => {
-  config.devtool = 'cheap-source-map';
+  config.devtool = 'cheap-module-source-map';
   // Remove test entries from being built
   config.entry = Object.entries(config.entry).reduce(
     (entry, [file, entries]) => {

--- a/packages/soy-gateway/src/lambdas/originRequest.js
+++ b/packages/soy-gateway/src/lambdas/originRequest.js
@@ -30,5 +30,10 @@ exports.handler = async event => {
     };
   }
 
+  // Forwarding host for cloudfront to use calculating a cache key
+  request.headers['x-forwarded-host'] = [
+    { key: 'X-Forwarded-Host', value: request.headers.host[0].value }
+  ];
+
   return request;
 };

--- a/packages/soy-gateway/src/lambdas/originRequest.test.js
+++ b/packages/soy-gateway/src/lambdas/originRequest.test.js
@@ -66,6 +66,16 @@ describe('Origin Request Lambda', () => {
     );
   });
 
+  it('it sets an x-forwarded-host header', async () => {
+    const originRequest = await simulateCloudfront(event);
+
+    expect(originRequest.headers['x-forwarded-host'][0]).toEqual(
+      expect.objectContaining({
+        value: request.headers.host[0].value
+      })
+    );
+  });
+
   it('it sets the origin path to contentHash with a nested uri', async () => {
     request.uri = '/static/index.js';
 

--- a/packages/soy-gateway/src/lambdas/originResponse.js
+++ b/packages/soy-gateway/src/lambdas/originResponse.js
@@ -1,0 +1,27 @@
+/**
+ * Origin response lambda handler.
+ *
+ * This lambda takes the response from the origin and modifies it. It's purpose
+ * is to take origin redirects and re-map them to the path expected from the request
+ *
+ * @param {Object} event - Cloudfront event
+ * @returns {Promise<Object>} - response object
+ */
+exports.handler = async event => {
+  const response = event.Records[0].cf.response;
+  const request = event.Records[0].cf.request;
+
+  // Normalize the redirect location to the request path
+  if (response.status === '301' || response.status === '302') {
+    const redirectLocation = response.headers['location'][0].value;
+    const requestUriPosition = redirectLocation.indexOf(request.uri);
+
+    if (requestUriPosition > 0) {
+      response.headers['location'][0].value = redirectLocation.substr(
+        requestUriPosition
+      );
+    }
+  }
+
+  return response;
+};

--- a/packages/soy-gateway/src/lambdas/originResponse.test.js
+++ b/packages/soy-gateway/src/lambdas/originResponse.test.js
@@ -1,0 +1,63 @@
+const {
+  setupEnsContracts,
+  registerAndPublishRevision
+} = require('soy-core/test/setup');
+const cfResponseEvent = require('../../test/fixtures/cf-response');
+const { handler } = require('./originResponse');
+
+describe('Origin Response Lambda', () => {
+  const contentHash = '/ipfs/QmVyYoFQ8KDLMUWhzxTn24js9g5BiC6QX3ZswfQ56T7A5T';
+
+  let event;
+  let response;
+  let request;
+
+  beforeAll(async () => {
+    const soy = await setupEnsContracts(web3, 'test', { from: accounts[0] });
+
+    await registerAndPublishRevision(soy, 'web3studio.test', contentHash);
+    await registerAndPublishRevision(
+      soy,
+      'trailing-slash.test',
+      `${contentHash}/`
+    );
+  });
+
+  beforeEach(() => {
+    event = cfResponseEvent();
+    response = event.Records[0].cf.response;
+    request = event.Records[0].cf.request;
+  });
+
+  it('passes response through on non-redirect', async () => {
+    const originResponse = await handler(event);
+
+    expect(originResponse).toEqual(response);
+  });
+
+  it('passes response through ipfs path redirect', async () => {
+    request.uri = `${contentHash}${request.uri}`;
+
+    response.status = '301';
+    response.headers.location = [{ key: 'Location', value: `${request.uri}/` }];
+
+    const originResponse = await handler(event);
+
+    expect(originResponse).toEqual(response);
+  });
+
+  it('on redirect, normalizes the location to the request uri', async () => {
+    response.status = '302';
+    response.headers.location = [
+      { key: 'Location', value: `${contentHash}${request.uri}/` }
+    ];
+    const originResponse = await handler(event);
+
+    expect(originResponse.headers['location'][0]).toEqual(
+      expect.objectContaining({
+        key: 'Location',
+        value: `${request.uri}/`
+      })
+    );
+  });
+});

--- a/packages/soy-gateway/template.yaml
+++ b/packages/soy-gateway/template.yaml
@@ -70,6 +70,17 @@ Resources:
       AutoPublishAlias: live
       Role: !GetAtt SoyEdgeFunctionIAMRole.Arn
 
+  SoyOriginResponseFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: build/lambdas/originResponse.js
+      Handler: index.handler
+      MemorySize: 128
+      Timeout: 5
+      Runtime: nodejs8.10
+      AutoPublishAlias: live
+      Role: !GetAtt SoyEdgeFunctionIAMRole.Arn
+
   Distribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -96,7 +107,9 @@ Resources:
           DefaultTTL: 86400 # 24 hours
           MinTTL: 900 # 15 minutes
           ForwardedValues:
-            Headers: ['X-Ipfs-Path']
+            Headers:
+              - X-Ipfs-Path
+              - X-Forwarded-Host
             Cookies:
               Forward: none
             QueryString: false
@@ -105,6 +118,8 @@ Resources:
               LambdaFunctionARN: !Ref SoyViewerRequestFunction.Version
             - EventType: origin-request
               LambdaFunctionARN: !Ref SoyOriginRequestFunction.Version
+            - EventType: origin-response
+              LambdaFunctionARN: !Ref SoyOriginResponseFunction.Version
 
   DNS:
     Type: AWS::Route53::RecordSetGroup

--- a/packages/soy-gateway/test/fixtures/cf-response.js
+++ b/packages/soy-gateway/test/fixtures/cf-response.js
@@ -1,0 +1,8 @@
+const event = require('./cf-response.json');
+
+/**
+ * Cloudfront viewer request event factory!
+ *
+ * @returns {Object} - A viewer request event
+ */
+module.exports = () => JSON.parse(JSON.stringify(event));

--- a/packages/soy-gateway/test/fixtures/cf-response.json
+++ b/packages/soy-gateway/test/fixtures/cf-response.json
@@ -5,6 +5,30 @@
         "config": {
           "distributionId": "EXAMPLE"
         },
+        "response": {
+          "status": "200",
+          "statusDescription": "OK",
+          "headers": {
+            "vary": [
+              {
+                "key": "Vary",
+                "value": "*"
+              }
+            ],
+            "last-modified": [
+              {
+                "key": "Last-Modified",
+                "value": "2016-11-25"
+              }
+            ],
+            "x-amz-meta-last-modified": [
+              {
+                "key": "X-Amz-Meta-Last-Modified",
+                "value": "2016-01-01"
+              }
+            ]
+          }
+        },
         "request": {
           "uri": "/web3studio",
           "method": "GET",


### PR DESCRIPTION
**Related Issue**  
Supports Consensys/web3studio-website#9

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
It maps redirect origin responses back to the requested host path. 

This came about as, after deploying to `web3studio.eth.soy/web3studio`, it would redirect to `/ipfs/QmcipiBV7vkJoJuL72yedJ4yWAUhRSDF6itvkvGKyLYPje/web3studio/` instead of `/web3studio/` like expected. This should fix that.

**Description of Changes**  
Added an origin-response lambda and cached on host as well as the origin-response contributes to what gets cached. Don't want to redirect poorly!

**What gif most accurately describes how I feel towards this PR?**  
![facehoof](https://media2.giphy.com/media/RulBEqSMUx5sI/giphy.gif)
