### PR TITLE
Add healthcheck for root soy website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build/
 coverage/
 coverage.json
 .env
-packaged.yaml
+*packaged.yaml

--- a/packages/soy-gateway/aws/deploy.sh
+++ b/packages/soy-gateway/aws/deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIRNAME="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+aws cloudformation deploy \
+  --template-file ${DIRNAME}/health-check.yaml \
+  --stack-name soy-gateway-health-check \
+  --parameter-overrides SNSNotificationEmail=${SLACK_ALARM_EMAIL}
+
+sam deploy \
+  --template-file ${DIRNAME}/gateway-packaged.yaml \
+  --stack-name soy-gateway-edge \
+  --capabilities CAPABILITY_IAM

--- a/packages/soy-gateway/aws/gateway.yaml
+++ b/packages/soy-gateway/aws/gateway.yaml
@@ -51,7 +51,7 @@ Resources:
   SoyViewerRequestFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/lambdas/viewerRequest.js
+      CodeUri: ../build/lambdas/viewerRequest.js
       Handler: index.handler
       MemorySize: 128
       Timeout: 5
@@ -62,7 +62,7 @@ Resources:
   SoyOriginRequestFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/lambdas/originRequest.js
+      CodeUri: ../build/lambdas/originRequest.js
       Handler: index.handler
       MemorySize: 128
       Timeout: 5
@@ -73,7 +73,7 @@ Resources:
   SoyOriginResponseFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: build/lambdas/originResponse.js
+      CodeUri: ../build/lambdas/originResponse.js
       Handler: index.handler
       MemorySize: 128
       Timeout: 5

--- a/packages/soy-gateway/aws/health-check.yaml
+++ b/packages/soy-gateway/aws/health-check.yaml
@@ -1,0 +1,48 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Route53HealthCheck
+Parameters:
+  SNSNotificationEmail:
+    Description: Email to send notifications to for a failure
+    Type: String
+
+Resources:
+  SoyHealthCheck:
+    Type: AWS::Route53::HealthCheck
+    Properties:
+      HealthCheckConfig:
+        Type: HTTPS_STR_MATCH
+        FullyQualifiedDomainName: web3studio.eth.soy
+        Port: '443'
+        ResourcePath: '/web3studio/'
+        SearchString: Web3Studio
+        MeasureLatency: true
+        RequestInterval: '30'
+        FailureThreshold: '3'
+
+  SoyHealthCheckTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: WebsiteHealthCheck
+      Subscription:
+        - Endpoint: !Ref 'SNSNotificationEmail'
+          Protocol: email
+
+  SoyHealthCheckCloudWatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: SoyHealthCheck
+      AlarmDescription: Health check for consensys.net/web3studio/
+      MetricName: HealthCheckStatus
+      ActionsEnabled: true
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: '1'
+      Namespace: AWS/Route53
+      Period: '60'
+      Statistic: Minimum
+      Threshold: '1.0'
+      AlarmActions:
+        - !Ref SoyHealthCheckTopic
+      Dimensions:
+        - Name: HealthCheckId
+          Value: !Ref SoyHealthCheck

--- a/packages/soy-gateway/aws/package.sh
+++ b/packages/soy-gateway/aws/package.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+DIRNAME="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+sam package --template-file ${DIRNAME}/gateway.yaml \
+  --output-template-file ${DIRNAME}/gateway-packaged.yaml \
+  --s3-bucket web3studio-lambdas

--- a/packages/soy-gateway/package.json
+++ b/packages/soy-gateway/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "start": "yarn lambda:build && sam local invoke SoyViewerRequestFunction --event test/fixtures/cf-request.json",
-    "sam:deploy": "sam deploy --template-file packaged.yaml --stack-name soy-gateway-edge --capabilities CAPABILITY_IAM",
-    "sam:package": "sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket web3studio-lambdas",
+    "sam:deploy": "./aws/deploy.sh",
+    "sam:package": "./aws/package.sh",
     "lambda:build": "rm -rf ./build/lambdas && lambda-tools-build -s soy-edge -n 8.10 -w scripts/transformWebpack -o ./build/lambdas src/lambdas",
     "lambda:deploy": "yarn lambda:build && yarn sam:package && yarn sam:deploy",
     "test": "jest",


### PR DESCRIPTION
**Related Issue**  
Supports #45 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Add's a health check via route53 to web3stuido.eth.soy/web3studio/. failures are sent to #web3studio-alarms

**Description of Changes**  
Moved the aws code into an `aws` folder to follow the website's pattern.

I chose to put the health check resources into it's own stack as the gateway takes forever to deploy. This allows for easier changes and testing.. 

**What gif most accurately describes how I feel towards this PR?**  
![fire](https://media2.giphy.com/media/urECjknRF8Tfi/giphy.gif)
